### PR TITLE
add: linting and formatting steps to CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,18 +13,25 @@ Thanks for your interest in contributing!
    ```bash
    git checkout -b your-feature-name
    ```
-3. Make changes, then test:
-   open index.html file in broswer.
-4. Commit and push:
+3. Install dependencies and run checks:
+   ```bash
+   npm install
+   npm run lint
+   npm run format:check
+   ```
+   If format:check reports any issues, fix them by running: `npm run format`
+4. Make changes, then test:
+   open index.html file in browser.
+5. Commit and push:
    ```bash
    git add .
    git commit -m "Your message"
    git push origin your-feature-branch-name
    ```
-5. Open Pull request on Github
+6. Open Pull request on Github
    - Go to your fork
    - Click Compare & pull request
-   - Add clear and description
+   - Add clear title and description
 
 ## Reporting Bugs
 
@@ -37,4 +44,4 @@ Open an issue with:
 
 Have a feature idea? Create an issue or discussion!
 
-Thanks again for helping improve Snake Game! 💚
+Thanks again for helping to improve Snake Game! 💚

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,14 +16,14 @@ Thanks for your interest in contributing!
 3. Install dependencies and run checks:
    ```bash
    npm install
-   npm run lint
-   npm run format:check
    ```
    If format:check reports any issues, fix them by running: `npm run format`
 4. Make changes, then test:
    open index.html file in browser.
 5. Commit and push:
    ```bash
+   npm run lint
+   npm run format:check
    git add .
    git commit -m "Your message"
    git push origin your-feature-branch-name


### PR DESCRIPTION
Fixes #33

Add linting and formatting workflow to CONTRIBUTING.md

- Add step 3: npm install, lint, and format:check commands with instructions
- Include npm run format fix command for resolving formatting issues
- Update step numbering to accommodate new linting workflow (steps 3-6 renumbered)
- Fix typo: "broswer" → "browser" 
- Fix incomplete sentence: "Add clear and description" → "Add clear title and description"
- Add "to" in final line: "helping improve" → "helping to improve"

Fixes the issue about adding pre-push linting checks to keep code consistent.
